### PR TITLE
Add more precompiled types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@
 *.exe
 *.out
 *.app
+
+# Generated header
+include/xtensor-zarr/xtensor_zarr_config_cling.hpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,7 +85,6 @@ find_dependency(xtl REQUIRED)
 # =====
 
 set(XTENSOR_ZARR_HEADERS
-    ${XTENSOR_ZARR_INCLUDE_DIR}/xtensor-zarr/xtensor_zarr_config.hpp
     ${XTENSOR_ZARR_INCLUDE_DIR}/xtensor-zarr/xzarr_hierarchy.hpp
     ${XTENSOR_ZARR_INCLUDE_DIR}/xtensor-zarr/xzarr_node.hpp
     ${XTENSOR_ZARR_INCLUDE_DIR}/xtensor-zarr/xzarr_group.hpp
@@ -97,6 +96,8 @@ set(XTENSOR_ZARR_HEADERS
     ${XTENSOR_ZARR_INCLUDE_DIR}/xtensor-zarr/xzarr_common.hpp
     ${XTENSOR_ZARR_INCLUDE_DIR}/xtensor-zarr/xzarr_compressor.hpp
     ${XTENSOR_ZARR_INCLUDE_DIR}/xtensor-zarr/xzarr_chunked_array.hpp
+    ${XTENSOR_ZARR_INCLUDE_DIR}/xtensor-zarr/xtensor_zarr_config.hpp
+    ${XTENSOR_ZARR_INCLUDE_DIR}/xtensor-zarr/xtensor_zarr_config_cling.hpp
 )
 
 add_library(xtensor-zarr-gdal SHARED
@@ -209,7 +210,12 @@ endif()
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 
-set(XTENSOR_ZARR_GDAL_INSTALL_LIBRARY_DIR "\"${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}\"")
+set(XTENSOR_ZARR_INSTALL_LIBRARY_DIR "\"${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}\"")
+
+configure_file (
+    "${XTENSOR_ZARR_INCLUDE_DIR}/xtensor-zarr/xtensor_zarr_config_cling.hpp.in"
+    "${XTENSOR_ZARR_INCLUDE_DIR}/xtensor-zarr/xtensor_zarr_config_cling.hpp"
+)
 
 install(TARGETS xtensor-zarr-gdal
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,17 +64,23 @@ option(DOWNLOAD_GBENCHMARK "download google benchmark and build from source" ON)
 
 set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" "${CMAKE_SOURCE_DIR}/cmake")
 
+set(xtensor_REQUIRED_VERSION "0.23.8")
+find_package(xtensor ${xtensor_REQUIRED_VERSION} REQUIRED)
+
+set(xtensor_io_REQUIRED_VERSION "0.12.7")
+find_package(xtensor-io ${xtensor_io_REQUIRED_VERSION} REQUIRED)
+
+set(zarray_REQUIRED_VERSION "0.1.0")
+find_package(zarray ${zarray_REQUIRED_VERSION} REQUIRED)
+
 set(nlohmann_json_REQUIRED_VERSION "3.2.0" )
 find_package(nlohmann_json ${nlohmann_json_REQUIRED_VERSION} REQUIRED)
 
-set(xtensor_REQUIRED_VERSION "0.23.7")
-find_package(xtensor-io ${xtensor_io_REQUIRED_VERSION} REQUIRED)
+set(GDAL_REQUIRED_VERSION "3.0.0")
+find_package(GDAL ${GDAL_REQUIRED_VERSION} REQUIRED)
 
-set(xtensor_io_REQUIRED_VERSION "0.12.6")
-find_package(xtensor-io ${xtensor_io_REQUIRED_VERSION} REQUIRED)
-
-set(zarray_REQUIRED_VERSION "0.0.6")
-find_package(zarray ${zarray_REQUIRED_VERSION} REQUIRED)
+set(Blosc_REQUIRED_VERSION "1.21.0")
+find_package(Blosc ${Blosc_REQUIRED_VERSION} REQUIRED)
 
 #Remove the following lines when xtensor-io is fixed
 include(CMakeFindDependencyMacro)
@@ -119,43 +125,68 @@ target_include_directories(xtensor-zarr-gdal
     $<INSTALL_INTERFACE:include>
 )
 
-message(STATUS "Trying to find GDAL for Virtual File System support")
-find_package(GDAL)
-if(${GDAL_FOUND})
-    message(STATUS "GDAL ${GDAL_VERSION} found, Virtual File System support enabled")
-    include_directories(${Blosc_INCLUDE_DIRS})
-    target_include_directories(xtensor-zarr
-        INTERFACE
-        $<BUILD_INTERFACE:${GDAL_INCLUDE_DIRS}>
-    )
-    target_link_libraries(xtensor-zarr
-        INTERFACE
-        ${GDAL_LIBRARIES}
-    )
-    target_link_libraries(xtensor-zarr-gdal
-        PRIVATE
-        ${GDAL_LIBRARIES}
-    )
-else()
-    message(WARNING "GDAL not found - install GDAL for Virtual File System support")
-endif()
+include_directories(${nlohmann_json_INCLUDE_DIRS})
+target_include_directories(xtensor-zarr
+    INTERFACE
+    $<BUILD_INTERFACE:${NLOHMANN_JSON_INCLUDE_DIRS}>
+)
+target_link_libraries(xtensor-zarr
+    INTERFACE
+    ${NLOHMANN_JSON_LIBRARIES}
+)
 
-message(STATUS "Trying to find Blosc for Blosc file support")
-find_package(Blosc)
-if (${Blosc_FOUND})
-    message(STATUS "Blosc found, Blosc file support enabled")
-    include_directories(${Blosc_INCLUDE_DIRS})
-    target_include_directories(xtensor-zarr
-        INTERFACE
-        $<BUILD_INTERFACE:${Blosc_INCLUDE_DIRS}>
-    )
-    target_link_libraries(xtensor-zarr
-        INTERFACE
-        ${Blosc_LIBRARIES}
-    )
-else()
-    message(WARNING "Blosc not found - install blosc for Blosc file support")
-endif()
+include_directories(${cpp_filesystem_INCLUDE_DIRS})
+target_include_directories(xtensor-zarr
+    INTERFACE
+    $<BUILD_INTERFACE:${CPP_FILESYSTEM_INCLUDE_DIRS}>
+)
+target_link_libraries(xtensor-zarr
+    INTERFACE
+    ${CPP_FILESYSTEM_LIBRARIES}
+)
+
+include_directories(${gdal_INCLUDE_DIRS})
+target_include_directories(xtensor-zarr
+    INTERFACE
+    $<BUILD_INTERFACE:${GDAL_INCLUDE_DIRS}>
+)
+target_link_libraries(xtensor-zarr
+    INTERFACE
+    ${GDAL_LIBRARIES}
+)
+target_link_libraries(xtensor-zarr-gdal
+    PRIVATE
+    ${GDAL_LIBRARIES}
+)
+
+include_directories(${Blosc_INCLUDE_DIRS})
+target_include_directories(xtensor-zarr
+    INTERFACE
+    $<BUILD_INTERFACE:${Blosc_INCLUDE_DIRS}>
+)
+target_link_libraries(xtensor-zarr
+    INTERFACE
+    ${Blosc_LIBRARIES}
+)
+target_link_libraries(xtensor-zarr-gdal
+    PRIVATE
+    ${Blosc_LIBRARIES}
+)
+
+find_package(ZLIB)
+include_directories(${zlib_INCLUDE_DIRS})
+target_include_directories(xtensor-zarr
+    INTERFACE
+    $<BUILD_INTERFACE:${zlib_INCLUDE_DIRS}>
+)
+target_link_libraries(xtensor-zarr
+    INTERFACE
+    ${zlib_LIBRARIES}
+)
+target_link_libraries(xtensor-zarr-gdal
+    PRIVATE
+    ZLIB::ZLIB
+)
 
 find_package(storage_client)
 message(STATUS "Trying to find Google Cloud Storage for GCS IO handler support")

--- a/README.md
+++ b/README.md
@@ -5,32 +5,26 @@
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/xtensor-stack/xtensor-zarr/master?urlpath=lab%2Ftree%2Fexamples)
 [![Join the Gitter Chat](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/QuantStack/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-Implementation of the Zarr version 3.0 core protocol based on xtensor
+Implementation of the Zarr core protocol (version 2 and 3) based on xtensor
 
 ## Introduction
 
-**xtensor-zarr is an early developer preview, and is not suitable for general usage yet. Features and implementation are subject to change.**
-
-`xtensor-zarr` offers an API to create and access a Zarr (v3) hierarchy in a store (locally or in the cloud), read and write arrays (in various formats) and groups in the hierarchy, and explore the hierarchy.
+`xtensor-zarr` offers an API to create and access a Zarr (v2 or v3) hierarchy in a store (locally or in the cloud), read and write arrays (in various formats) and groups in the hierarchy, and explore the hierarchy.
 
 ## Installation
 
-`xtensor-zarr` is a header-only library. We provide a package for the mamba (or conda) package manager.
+`xtensor-zarr` comes with a `libxtensor-zarr-gdal` shared library for accessing stores through a GDAL Virtual File System, but is otherwise a header-only library. We provide a package for the mamba (or conda) package manager.
 
 ```bash
 mamba install xtensor-zarr -c conda-forge
 ```
 
-- `xtensor-zarr` depends on `xtensor` `^0.23.4`, `xtensor-io` `^0.12.4`, `zarray` `^0.0.5` and `nlohmann_json`.
+- `xtensor-zarr` depends on `xtensor` `^0.23.8`, `xtensor-io` `^0.12.7`, `zarray` `^0.0.7`, `nlohmann_json` `^3.2.0`, `cpp-filesystem` `^1.5.0`, `gdal` `^3.2.0`, `Blosc` `^1.21.0` and `zlib` `^1.2.0`.
 
-- `google-cloud-cpp`, `aws-sdk-cpp`, `cpp-filesystem`, `zlib`, `blosc` and `gdal` are optional dependencies to `xtensor-zarr`.
+- `google-cloud-cpp` and `aws-sdk-cpp` are optional dependencies to `xtensor-zarr`.
 
   - `google-cloud-cpp` is required to access a store in Google Cloud Storage.
   - `aws-sdk-cpp` is required to access a store in AWS S3.
-  - `cpp-filesystem` is required to access a store on the local file system.
-  - `zlib` is required for the GZip compressor.
-  - `blosc` is required for the Blosc compressor.
-  - `gdal` is required to access a store through its Virtual File System.
 
 You can also install `xtensor-zarr` from source:
 

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -18,6 +18,7 @@ dependencies:
   - google-cloud-cpp=1.20.0
   - zlib
   - blosc
+  - gdal
   - allthekernels
   - fsspec
   - numcodecs

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -9,9 +9,7 @@ dependencies:
   - jupyterlab_widgets=1.0.0
   - ffmpeg=4.3.1  # openimageio is being added as a runtime requirement to xtensor-io
   - widgetsnbextension
-  - xtensor=0.23.7
-  - xtensor-io=0.12.6
-  - zarray=0.0.6
+  - xtensor-zarr=0.0.5
   - cppcolormap=1.3.0
   - bash_kernel
   - nlohmann_json

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -10,10 +10,10 @@ dependencies:
   - aws-sdk-cpp
   - cpp-filesystem
   - zlib
-  - xtensor=0.23.7
-  - xtensor-io=0.12.6
-  - gdal
-  - zarray=0.0.6
+  - xtensor=0.23.8
+  - xtensor-io=0.12.7
+  - zarray=0.1.0
+  - gdal=3.0.4
   # Test dependencies
   - fsspec
   - numpy

--- a/examples/xtensor-zarr-gdal.ipynb
+++ b/examples/xtensor-zarr-gdal.ipynb
@@ -1,0 +1,113 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "61829be3-6fab-4500-8d88-7c61ad7b8747",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#include \"xtensor/xio.hpp\"\n",
+    "#include \"xtensor-io/xio_blosc.hpp\"\n",
+    "#include \"xtensor-zarr/xzarr_hierarchy.hpp\"\n",
+    "#include \"xtensor-zarr/xzarr_compressor.hpp\"\n",
+    "#include \"xtensor-zarr/xzarr_gdal_store.hpp\"\n",
+    "#include \"xtensor-zarr/xtensor_zarr_config_cling.hpp\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e2aac83c-691b-4bfb-a345-ac72708168fe",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xt::xzarr_register_compressor<xt::xzarr_gdal_store, xt::xio_blosc_config>();\n",
+    "std::vector<size_t> shape = {4, 4};\n",
+    "std::vector<size_t> chunk_shape = {2, 2};\n",
+    "nlohmann::json attrs = {{\"question\", \"life\"}, {\"answer\", 42}};\n",
+    "std::size_t pool_size = 1;\n",
+    "double fill_value = 6.6;\n",
+    "std::string zarr_version = \"3\";\n",
+    "xt::xzarr_gdal_store store(\"/vsimem/test.zr\" + zarr_version);\n",
+    "auto h1 = xt::create_zarr_hierarchy(store, zarr_version);\n",
+    "xt::xzarr_create_array_options<xt::xio_blosc_config> o;\n",
+    "o.chunk_memory_layout = 'C';\n",
+    "o.chunk_separator = '/';\n",
+    "o.attrs = attrs;\n",
+    "o.chunk_pool_size = pool_size;\n",
+    "o.fill_value = fill_value;\n",
+    "auto z1 = h1.create_array(\"/arthur/dent\", shape, chunk_shape, \"<f8\", o);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cffbab84-ec62-4641-a644-ee85f545a345",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xt::xarray<double> a1 = xt::arange(0, 16).reshape({4, 4});"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4fc286dd-3809-4c19-88ef-62541fbedb8b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "noalias(z1) = a1;"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "63f4c900-6b55-4f6e-884e-8e0aa57e6145",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "auto a2 = z1.get_array<double>();\n",
+    "a2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9386a0ed-4a3d-4626-856d-e60f3d5c32ad",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "auto h2 = xt::get_zarr_hierarchy(store);\n",
+    "auto z2 = h2.get_array(\"/arthur/dent\");"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "935f7a10-6fab-4ac3-bd3a-15e0b28a3c08",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "auto a3 = z2.get_array<double>();\n",
+    "a3"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "C++14",
+   "language": "C++14",
+   "name": "xcpp14"
+  },
+  "language_info": {
+   "codemirror_mode": "text/x-c++src",
+   "file_extension": ".cpp",
+   "mimetype": "text/x-c++src",
+   "name": "c++",
+   "version": "14"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/include/xtensor-zarr/xtensor_zarr_config_cling.hpp.in
+++ b/include/xtensor-zarr/xtensor_zarr_config_cling.hpp.in
@@ -14,5 +14,6 @@
 #pragma cling load("libxtensor-zarr-gdal")
 #pragma cling load("libgdal")
 #pragma cling load("libblosc")
+#pragma cling load("libz")
 
 #endif

--- a/include/xtensor-zarr/xtensor_zarr_config_cling.hpp.in
+++ b/include/xtensor-zarr/xtensor_zarr_config_cling.hpp.in
@@ -1,0 +1,18 @@
+/***************************************************************************
+* Copyright (c) 2017, Sylvain Corlay and Johan Mabille                     *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XTENSOR_ZARR_CONFIG_CLING_HPP
+#define XTENSOR_ZARR_CONFIG_CLING_HPP
+
+#pragma cling add_include_path("@XTENSOR_ZARR_INCLUDE_DIR@")
+#pragma cling add_library_path(@XTENSOR_ZARR_INSTALL_LIBRARY_DIR@)
+#pragma cling load("libxtensor-zarr-gdal")
+#pragma cling load("libgdal")
+#pragma cling load("libblosc")
+
+#endif

--- a/include/xtensor-zarr/xzarr_hierarchy.hpp
+++ b/include/xtensor-zarr/xzarr_hierarchy.hpp
@@ -19,6 +19,9 @@
 #include "xzarr_file_system_store.hpp"
 #include "xzarr_gdal_store.hpp"
 #include "xtensor_zarr_config.hpp"
+#include "xtensor-io/xio_gzip.hpp"
+#include "xtensor-io/xio_zlib.hpp"
+#include "xtensor-io/xio_blosc.hpp"
 
 namespace xt
 {
@@ -224,7 +227,15 @@ namespace xt
      * precompiled types *
      *********************/
 
-    extern template class xzarr_hierarchy<xzarr_gdal_store>;
+    extern template void xzarr_register_compressor<xzarr_gdal_store, xio_gzip_config>();
+    extern template void xzarr_register_compressor<xzarr_gdal_store, xio_zlib_config>();
+    extern template void xzarr_register_compressor<xzarr_gdal_store, xio_blosc_config>();
+    extern template class xchunked_array_factory<xzarr_gdal_store>;
+
+    extern template void xzarr_register_compressor<xzarr_file_system_store, xio_gzip_config>();
+    extern template void xzarr_register_compressor<xzarr_file_system_store, xio_zlib_config>();
+    extern template void xzarr_register_compressor<xzarr_file_system_store, xio_blosc_config>();
+    extern template class xchunked_array_factory<xzarr_file_system_store>;
 }
 
 #endif

--- a/src/xtensor-zarr-gdal.cpp
+++ b/src/xtensor-zarr-gdal.cpp
@@ -2,5 +2,13 @@
 
 namespace xt
 {
-    template class XTENSOR_ZARR_API xzarr_hierarchy<xzarr_gdal_store>;
+    template XTENSOR_ZARR_API void xzarr_register_compressor<xzarr_gdal_store, xio_gzip_config>();
+    template XTENSOR_ZARR_API void xzarr_register_compressor<xzarr_gdal_store, xio_zlib_config>();
+    template XTENSOR_ZARR_API void xzarr_register_compressor<xzarr_gdal_store, xio_blosc_config>();
+    template class XTENSOR_ZARR_API xchunked_array_factory<xzarr_gdal_store>;
+
+    template XTENSOR_ZARR_API void xzarr_register_compressor<xzarr_file_system_store, xio_gzip_config>();
+    template XTENSOR_ZARR_API void xzarr_register_compressor<xzarr_file_system_store, xio_zlib_config>();
+    template XTENSOR_ZARR_API void xzarr_register_compressor<xzarr_file_system_store, xio_blosc_config>();
+    template class XTENSOR_ZARR_API xchunked_array_factory<xzarr_file_system_store>;
 }


### PR DESCRIPTION
This allows for fast compilation of xtensor-zarr when used with a GDAL or local file system IO handler, with zlib, GZip or Blosc compression (or no compression). It produces a 20M shared library.