### PR TITLE
Added target_include_directories when building shared libs to target …

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -304,6 +304,11 @@ if (XTENSOR_ZARR_BUILD_SHARED_LIBS)
     xtensor_zarr_create_target(${XTENSOR_ZARR_GDAL_SOURCE} xtensor-zarr-gdal SHARED xtensor-zarr-gdal)
     list(APPEND xtensor_zarr_targets xtensor-zarr-gdal)
 
+    target_include_directories(xtensor-zarr-gdal
+      PRIVATE
+      ${GDAL_INCLUDE_DIRS}
+    )
+
     target_link_libraries(xtensor-zarr-gdal
         PRIVATE
         ${GDAL_LIBRARIES}


### PR DESCRIPTION
When trying to build xtensor-zarr on Ubuntu 20.04 I run into problem because some of the gdal headers where not found. I installed gdal via sudo apt, so everything was in place and cmake find_package worked well.

Investigating a little bit more, I found, that there might be a missing target_include_directories, see the diff.