### PR TITLE
Various fixes and improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Implementation of the Zarr core protocol (version 2 and 3) based on xtensor
 
 ## Installation
 
-`xtensor-zarr` comes with a `libxtensor-zarr-gdal` shared library for accessing stores through GDAL's Virtual File System or the local file system. For all other stores, `xtensor-zarr` is a header-only library.
+`xtensor-zarr` comes with a `libxtensor-zarr-gdal` shared library for accessing stores through GDAL's Virtual File System or the local file system. For all other stores, `xtensor-zarr` is a header-only library. If you do not link your project against `xtensor-zarr-gdal` target, you should add code from [xtensor-zarr-gdal.cpp](https://github.com/xtensor-stack/xtensor-zarr/blob/90f0acfbf74a4e3664b0861920409b6143600d67/src/xtensor-zarr-gdal.cpp#L3-L8) somewhere in your project to avoid linking errors.
 
 We provide a package for the mamba (or conda) package manager:
 

--- a/docs/source/basic_usage.rst
+++ b/docs/source/basic_usage.rst
@@ -54,22 +54,25 @@ Create an array
         auto h = xt::get_zarr_hierarchy(store);
         // create an array in the hierarchy
         nlohmann::json attrs = {{"question", "life"}, {"answer", 42}};
-        using S = std::vector<std::size_t>;
-        S shape = {4, 4};
-        S chunk_shape = {2, 2};
-        xt::zarray a = h.create_array(
+        std::vector<size_t> shape = {4, 4};
+        std::vector<size_t> chunk_shape = {2, 2};
+        // specify options
+        xt::xzarr_create_array_options<xt::xio_gzip_config> o;
+        o.chunk_memory_layout = 'C';
+        o.chunk_separator = '/';
+        o.attrs = attrs;
+        o.chunk_pool_size = 10;
+        o.fill_value = 0.0;
+
+        xt::zarray z = h.create_array(
             "/arthur/dent",  // path to the array in the store
             shape,  // array shape
             chunk_shape,  // chunk shape
             "<f8",  // data type, here little-endian 64-bit floating point
-            'C',  // memory layout
-            '/',  // chunk identifier separator
-            xt::xio_binary_config(),  // compressor (here, raw binary)
-            attrs,  // attributes
-            10,  // chunk pool size
-            0.  // fill value
+            o // options
         );
         // write array data
+        auto a = z.get_array<double>();
         a(2, 1) = 3.;
     }
 

--- a/include/xtensor-zarr/xzarr_node.hpp
+++ b/include/xtensor-zarr/xzarr_node.hpp
@@ -68,7 +68,7 @@ namespace xt
         {
             m_path = '/' + m_path;
         }
-        while (m_path.back() == '/')
+        while (!m_path.empty() && m_path.back() == '/')
         {
             m_path = m_path.substr(0, m_path.size() - 1);
         }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -79,10 +79,16 @@ include_directories(${GTEST_INCLUDE_DIRS} SYSTEM)
 set(XTENSOR_ZARR_TESTS
     main.cpp
     test_zarr.cpp
-    test_gcs.cpp
-    test_aws.cpp
     test_gdal.cpp
 )
+
+if(${storage_client_FOUND})
+  list(APPEND XTENSOR_ZARR_TESTS test_gcs.cpp)
+endif()
+
+if(${AWSSDK_FOUND})
+  list(APPEND XTENSOR_ZARR_TESTS test_aws.cpp)
+endif()
 
 add_executable(test_xtensor_zarr ${XTENSOR_ZARR_TESTS} ${XTENSOR_ZARR_HEADERS})
 if(DOWNLOAD_GTEST OR GTEST_SRC_DIR)

--- a/xtensor-zarrConfig.cmake.in
+++ b/xtensor-zarrConfig.cmake.in
@@ -21,10 +21,6 @@ find_dependency(xtensor-io @xtensor_io_REQUIRED_VERSION@)
 find_dependency(zarray @zarray_REQUIRED_VERSION@)
 find_dependency(nlohmann_json @nlohmann_json_REQUIRED_VERSION@)
 
-set(PN xtensor_zarr)
-set_and_check(${PN}_INCLUDE_DIRS "${PACKAGE_PREFIX_DIR}/@CMAKE_INSTALL_INCLUDEDIR@")
-set(${PN}_LIBRARY "")
-check_required_components(${PN})
 
 if(NOT TARGET @PROJECT_NAME@)
   include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")


### PR DESCRIPTION
The error was:
```text
CMake Error at C:/Libs/xtl-vs19/xtlConfig.cmake:26 (message):
  File or directory C://include referenced by variable
  xtensor_zarr_INCLUDE_DIRS does not exist !
Call Stack (most recent call first):
  C:/Libs/xtensor-zarr-vs19/xtensor-zarrConfig.cmake:49 (set_and_check)
  CMakeLists.txt:6 (find_package)
```