### PR TITLE
[WIP] Create CMake Options to disable the requirement for GDAL.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,14 +76,23 @@ find_package(zarray ${zarray_REQUIRED_VERSION} REQUIRED)
 set(nlohmann_json_REQUIRED_VERSION "3.9.1" )
 find_package(nlohmann_json ${nlohmann_json_REQUIRED_VERSION} REQUIRED)
 
-set(GDAL_REQUIRED_VERSION "3.0.0")
-find_package(GDAL ${GDAL_REQUIRED_VERSION} REQUIRED)
+option(XTENSOR_ZARR_ENABLE_GDAL "Enable GDAL Support" OFF)
+if(XTENSOR_ZARR_ENABLE_GDAL)
+    set(GDAL_REQUIRED_VERSION "3.0.0")
+    find_package(GDAL ${GDAL_REQUIRED_VERSION} REQUIRED)
+endif()
 
-set(Blosc_REQUIRED_VERSION "1.21.0")
-find_package(Blosc ${Blosc_REQUIRED_VERSION} REQUIRED)
+option(XTENSOR_ZARR_ENABLE_BLOSC "Enable BLOSC Support" OFF)
+if(XTENSOR_ZARR_ENABLE_BLOSC)
+    set(Blosc_REQUIRED_VERSION "1.21.0")
+    find_package(Blosc ${Blosc_REQUIRED_VERSION} REQUIRED)
+endif()
 
-set(ZLIB_REQUIRED_VERSION "1.2.11")
-find_package(ZLIB ${ZLIB_REQUIRED_VERSION} REQUIRED)
+option(XTENSOR_ZARR_ENABLE_ZLIB "Enable ZLIB Support" OFF)
+if(XTENSOR_ZARR_ENABLE_ZLIB)
+    set(ZLIB_REQUIRED_VERSION "1.2.11")
+    find_package(ZLIB ${ZLIB_REQUIRED_VERSION} REQUIRED)
+endif()
 
 #Remove the following lines when xtensor-io is fixed
 include(CMakeFindDependencyMacro)
@@ -101,17 +110,24 @@ set(XTENSOR_ZARR_HEADERS
     ${XTENSOR_ZARR_INCLUDE_DIR}/xtensor-zarr/xzarr_file_system_store.hpp
     ${XTENSOR_ZARR_INCLUDE_DIR}/xtensor-zarr/xzarr_gcs_store.hpp
     ${XTENSOR_ZARR_INCLUDE_DIR}/xtensor-zarr/xzarr_aws_store.hpp
-    ${XTENSOR_ZARR_INCLUDE_DIR}/xtensor-zarr/xzarr_gdal_store.hpp
     ${XTENSOR_ZARR_INCLUDE_DIR}/xtensor-zarr/xzarr_common.hpp
     ${XTENSOR_ZARR_INCLUDE_DIR}/xtensor-zarr/xzarr_compressor.hpp
     ${XTENSOR_ZARR_INCLUDE_DIR}/xtensor-zarr/xzarr_chunked_array.hpp
     ${XTENSOR_ZARR_INCLUDE_DIR}/xtensor-zarr/xtensor_zarr_config.hpp
     ${XTENSOR_ZARR_INCLUDE_DIR}/xtensor-zarr/xtensor_zarr_config_cling.hpp
 )
+if(XTENSOR_ZARR_ENABLE_GDAL)
 
-set(XTENSOR_ZARR_GDAL_SOURCE
-    ${XTENSOR_ZARR_SOURCE_DIR}/xtensor-zarr-gdal.cpp
-)
+    set(XTENSOR_ZARR_HEADERS
+        ${XTENSOR_ZARR_HEADERS}
+        ${XTENSOR_ZARR_INCLUDE_DIR}/xtensor-zarr/xzarr_gdal_store.hpp
+    )
+
+    set(XTENSOR_ZARR_GDAL_SOURCE
+        ${XTENSOR_ZARR_SOURCE_DIR}/xtensor-zarr-gdal.cpp
+    )
+endif()
+
 
 add_library(xtensor-zarr INTERFACE)
 target_link_libraries(xtensor-zarr INTERFACE xtensor-io zarray)
@@ -140,32 +156,38 @@ target_link_libraries(xtensor-zarr
     ${CPP_FILESYSTEM_LIBRARIES}
 )
 
-target_include_directories(xtensor-zarr
-    INTERFACE
-    $<BUILD_INTERFACE:${GDAL_INCLUDE_DIRS}>
-)
-target_link_libraries(xtensor-zarr
-    INTERFACE
-    ${GDAL_LIBRARIES}
-)
+if(XTENSOR_ZARR_ENABLE_GDAL)
+    target_include_directories(xtensor-zarr
+        INTERFACE
+        $<BUILD_INTERFACE:${GDAL_INCLUDE_DIRS}>
+    )
+    target_link_libraries(xtensor-zarr
+        INTERFACE
+        ${GDAL_LIBRARIES}
+    )
+endif()
 
-target_include_directories(xtensor-zarr
-    INTERFACE
-    $<BUILD_INTERFACE:${Blosc_INCLUDE_DIRS}>
-)
-target_link_libraries(xtensor-zarr
-    INTERFACE
-    ${Blosc_LIBRARIES}
-)
+if(XTENSOR_ZARR_ENABLE_BLOSC)
+    target_include_directories(xtensor-zarr
+        INTERFACE
+        $<BUILD_INTERFACE:${Blosc_INCLUDE_DIRS}>
+    )
+    target_link_libraries(xtensor-zarr
+        INTERFACE
+        ${Blosc_LIBRARIES}
+    )
+endif()
 
-target_include_directories(xtensor-zarr
-    INTERFACE
-    $<BUILD_INTERFACE:${zlib_INCLUDE_DIRS}>
-)
-target_link_libraries(xtensor-zarr
-    INTERFACE
-    ${zlib_LIBRARIES}
-)
+if(XTENSOR_ZARR_ENABLE_ZLIB)
+    target_include_directories(xtensor-zarr
+        INTERFACE
+        $<BUILD_INTERFACE:${zlib_INCLUDE_DIRS}>
+    )
+    target_link_libraries(xtensor-zarr
+        INTERFACE
+        ${zlib_LIBRARIES}
+    )
+endif()
 
 find_package(storage_client)
 message(STATUS "Trying to find Google Cloud Storage for GCS IO handler support")
@@ -377,3 +399,35 @@ configure_file(${PROJECT_NAME}.pc.in
                 @ONLY)
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc"
         DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig/")
+
+install(FILES ${XTENSOR_ZARR_HEADERS}
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/xtensor-zarr
+)
+
+add_executable(zarr_v3_example ${xtensor-zarr_SOURCE_DIR}/examples/zarr_v3_example.cpp)
+if(XTENSOR_ZARR_ENABLE_GDAL)
+    target_compile_definitions(zarr_v3_example PUBLIC "-DXTENSOR_ZARR_ENABLE_GDAL=1")
+endif()
+if(XTENSOR_ZARR_ENABLE_ZLIB)
+    target_compile_definitions(zarr_v3_example PUBLIC "-DXTENSOR_ZARR_ENABLE_ZLIB=1")
+endif()
+if(XTENSOR_ZARR_ENABLE_BLOSC)
+    target_compile_definitions(zarr_v3_example PUBLIC "-DXTENSOR_ZARR_ENABLE_BLOSC=1")
+endif()
+
+target_include_directories(
+    zarr_v3_example
+    PUBLIC
+    $<BUILD_INTERFACE:${XTENSOR_ZARR_INCLUDE_DIR}>
+    $<BUILD_INTERFACE:${xtensor_INCLUDE_DIRS}>
+
+    $<BUILD_INTERFACE:${ghc-filesystem-include}>
+    $<INSTALL_INTERFACE:include>
+)
+
+target_link_libraries(
+    zarr_v3_example
+    PUBLIC nlohmann_json::nlohmann_json
+    PUBLIC xtl
+    PUBLIC xtensor-zarr xtensor xtensor-io zarray
+)

--- a/examples/zarr_v3_example.cpp
+++ b/examples/zarr_v3_example.cpp
@@ -1,0 +1,49 @@
+#include "xtensor/xio.hpp"
+#include "xtensor/xview.hpp"
+#include "xtensor/xchunked_array.hpp"
+#include "xtensor-io/xchunk_store_manager.hpp"
+#include "xtensor-zarr/xzarr_array.hpp"
+#include "xtensor-zarr/xzarr_hierarchy.hpp"
+#include "xtensor-zarr/xzarr_file_system_store.hpp"
+#include "zarray/zarray_zarray.hpp"
+
+namespace xt
+{
+    template class XTENSOR_ZARR_API xchunked_array_factory<xzarr_file_system_store>;
+}
+
+
+#include <iostream>
+#include <string>
+#include <vector>
+
+int main(int32_t argc, char **argv) {
+  std::cout << "Hello World" << std::endl;
+
+
+  std::vector<size_t> shape = {4, 4};
+  std::vector<size_t> chunk_shape = {2, 2};
+  auto h = xt::create_zarr_hierarchy("h_xtensor.zr3");
+  xt::xzarr_create_array_options<> o;
+  o.chunk_memory_layout = 'C';
+  o.chunk_separator = '/';
+  o.attrs = {{"question", "life"}, {"answer", 42}};
+  o.chunk_pool_size = 1;
+  o.fill_value = 6.6;
+  {
+    xt::zarray z = h.create_array("/arthur/dent", shape, chunk_shape, "<f8", o);
+    auto chunked_array = z.as_chunked_array();
+
+  }
+  xt::zarray z = h.get_array("/arthur/dent");
+  auto a = z.get_array<double>();
+  
+  for (size_t i = 0; i < 4; i++) {
+    for (size_t j = 0; j < 4; j++) {
+      //z(i, j, static_cast<double>(i * j));
+      a(2, 1) = 3.;
+      }
+    }
+
+  return 0;
+}

--- a/include/xtensor-zarr/xzarr_hierarchy.hpp
+++ b/include/xtensor-zarr/xzarr_hierarchy.hpp
@@ -17,11 +17,20 @@
 #include "xzarr_group.hpp"
 #include "xzarr_common.hpp"
 #include "xzarr_file_system_store.hpp"
+
+#ifdef XTENSOR_ZARR_ENABLE_GDAL
 #include "xzarr_gdal_store.hpp"
-#include "xtensor_zarr_config.hpp"
 #include "xtensor-io/xio_gzip.hpp"
+#endif
+#include "xtensor_zarr_config.hpp"
+
+#ifdef XTENSOR_ZARR_ENABLE_ZLIB
 #include "xtensor-io/xio_zlib.hpp"
+#endif
+
+#ifdef XTENSOR_ZARR_ENABLE_BLOSC
 #include "xtensor-io/xio_blosc.hpp"
+#endif
 
 namespace xt
 {
@@ -226,15 +235,22 @@ namespace xt
     /*********************
      * precompiled types *
      *********************/
-
+#ifdef XTENSOR_ZARR_ENABLE_GDAL
     extern template void xzarr_register_compressor<xzarr_gdal_store, xio_gzip_config>();
     extern template void xzarr_register_compressor<xzarr_gdal_store, xio_zlib_config>();
     extern template void xzarr_register_compressor<xzarr_gdal_store, xio_blosc_config>();
     extern template class xchunked_array_factory<xzarr_gdal_store>;
-
     extern template void xzarr_register_compressor<xzarr_file_system_store, xio_gzip_config>();
+#endif
+
+#ifdef XTENSOR_ZARR_ENABLE_ZIP
     extern template void xzarr_register_compressor<xzarr_file_system_store, xio_zlib_config>();
+#endif
+
+#ifdef XTENSOR_ZARR_ENABLE_BLOSC
     extern template void xzarr_register_compressor<xzarr_file_system_store, xio_blosc_config>();
+#endif
+
     extern template class xchunked_array_factory<xzarr_file_system_store>;
 }
 


### PR DESCRIPTION
* Add installation rules for the headers
* Add example file to write a zarr array (not working)

The example does not work because we could not find a way to actually write data to the zarray?


Signed-off-by: Michael Jackson <mike.jackson@bluequartz.net>